### PR TITLE
refactor: simplify event stream and store implementation details

### DIFF
--- a/account-service/src/main/java/lt/rieske/accounts/eventsourcing/AggregateRepository.java
+++ b/account-service/src/main/java/lt/rieske/accounts/eventsourcing/AggregateRepository.java
@@ -56,10 +56,15 @@ public class AggregateRepository<A extends EventVisitor<E>, E extends Event> {
     }
 
     public A query(UUID aggregateId) {
-        return loadAggregate(readOnlyEventStream(), aggregateId);
+        EventStream<A, E> readOnlyStream = (event, aggregate, id) -> {
+            throw new UnsupportedOperationException("Can not append to read only event stream");
+        };
+        var aggregate = aggregateFactory.makeAggregate(readOnlyStream, aggregateId);
+        new EventReplayer<>(eventStore).replay(aggregate, aggregateId);
+        return aggregate;
     }
 
-    private A loadAggregate(ReplayingEventStream<A, E> eventStream, UUID aggregateId) {
+    private A loadAggregate(TransactionalEventStream<A, E> eventStream, UUID aggregateId) {
         var aggregate = aggregateFactory.makeAggregate(eventStream, aggregateId);
         eventStream.replay(aggregate, aggregateId);
         return aggregate;
@@ -68,10 +73,4 @@ public class AggregateRepository<A extends EventVisitor<E>, E extends Event> {
     private TransactionalEventStream<A, E> transactionalEventStream() {
         return new TransactionalEventStream<>(eventStore, snapshotter);
     }
-
-    private ReplayingEventStream<A, E> readOnlyEventStream() {
-        return new ReplayingEventStream<>(eventStore);
-    }
 }
-
-

--- a/account-service/src/main/java/lt/rieske/accounts/eventsourcing/EventReplayer.java
+++ b/account-service/src/main/java/lt/rieske/accounts/eventsourcing/EventReplayer.java
@@ -3,22 +3,15 @@ package lt.rieske.accounts.eventsourcing;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 
 
-class ReplayingEventStream<A extends EventVisitor<E>, E extends Event> implements EventStream<A, E> {
+class EventReplayer<A extends EventVisitor<E>, E extends Event> {
 
-    final EventStore<E> eventStore;
+    private final EventStore<E> eventStore;
+    private final Map<UUID, Long> aggregateVersions = new HashMap<>();
 
-    final Map<UUID, Long> aggregateVersions = new HashMap<>();
-
-    ReplayingEventStream(EventStore<E> eventStore) {
+    EventReplayer(EventStore<E> eventStore) {
         this.eventStore = eventStore;
-    }
-
-    @Override
-    public void append(E event, A aggregate, UUID aggregateId) {
-        throw new UnsupportedOperationException("Can not append to read only event stream");
     }
 
     void replay(A aggregate, UUID aggregateId) {
@@ -32,6 +25,10 @@ class ReplayingEventStream<A extends EventVisitor<E>, E extends Event> implement
         aggregateVersions.put(aggregateId, currentVersion);
     }
 
+    long nextVersion(UUID aggregateId) {
+        return aggregateVersions.compute(aggregateId, (id, version) -> version != null ? version + 1 : 1);
+    }
+
     private long applySnapshot(A aggregate, UUID aggregateId) {
         SequencedEvent<E> snapshot = eventStore.loadSnapshot(aggregateId);
         if (snapshot != null) {
@@ -42,12 +39,12 @@ class ReplayingEventStream<A extends EventVisitor<E>, E extends Event> implement
     }
 
     private long replayEvents(A aggregate, long startingVersion, UUID aggregateId) {
-        var events = eventStore.getEvents(aggregateId, startingVersion);
-        var currentVersion = new AtomicLong(startingVersion);
-        events.forEach(event -> {
+        long currentVersion = startingVersion;
+        for (var iterator = eventStore.getEvents(aggregateId, startingVersion).iterator(); iterator.hasNext(); ) {
+            var event = iterator.next();
             aggregate.visit(event.event());
-            currentVersion.set(event.sequenceNumber());
-        });
-        return currentVersion.get();
+            currentVersion = event.sequenceNumber();
+        }
+        return currentVersion;
     }
 }

--- a/account-service/src/main/java/lt/rieske/accounts/eventsourcing/TransactionalEventStream.java
+++ b/account-service/src/main/java/lt/rieske/accounts/eventsourcing/TransactionalEventStream.java
@@ -7,27 +7,34 @@ import java.util.Map;
 import java.util.UUID;
 
 
-class TransactionalEventStream<A extends EventVisitor<E>, E extends Event> extends ReplayingEventStream<A, E> {
+class TransactionalEventStream<A extends EventVisitor<E>, E extends Event> implements EventStream<A, E> {
 
+    private final EventStore<E> eventStore;
+    private final EventReplayer<A, E> replayer;
     private final Snapshotter<A, E> snapshotter;
 
     private final List<SequencedEvent<E>> uncommittedEvents = new ArrayList<>();
     private final Map<UUID, SequencedEvent<E>> uncommittedSnapshots = new HashMap<>();
 
     TransactionalEventStream(EventStore<E> eventStore, Snapshotter<A, E> snapshotter) {
-        super(eventStore);
+        this.eventStore = eventStore;
+        this.replayer = new EventReplayer<>(eventStore);
         this.snapshotter = snapshotter;
     }
 
     @Override
     public void append(E event, A aggregate, UUID aggregateId) {
         aggregate.visit(event);
-        long currentVersion = aggregateVersions.compute(aggregateId, (id, version) -> version != null ? version + 1 : 1);
+        long currentVersion = replayer.nextVersion(aggregateId);
         uncommittedEvents.add(new SequencedEvent<>(aggregateId, currentVersion, null, event));
         var snapshotEvent = snapshotter.takeSnapshot(aggregate, currentVersion);
         if (snapshotEvent != null) {
             uncommittedSnapshots.put(aggregateId, new SequencedEvent<>(aggregateId, currentVersion, null, snapshotEvent));
         }
+    }
+
+    void replay(A aggregate, UUID aggregateId) {
+        replayer.replay(aggregate, aggregateId);
     }
 
     void commit(UUID transactionId) {

--- a/account-service/src/main/java/lt/rieske/accounts/eventstore/EventSerializer.java
+++ b/account-service/src/main/java/lt/rieske/accounts/eventstore/EventSerializer.java
@@ -3,6 +3,6 @@ package lt.rieske.accounts.eventstore;
 import lt.rieske.accounts.eventsourcing.Event;
 
 interface EventSerializer<E extends Event> {
-    byte[] serialize(Event event);
+    byte[] serialize(E event);
     E deserialize(byte[] serializedEvent);
 }

--- a/account-service/src/main/java/lt/rieske/accounts/eventstore/MessagePackAccountEventSerializer.java
+++ b/account-service/src/main/java/lt/rieske/accounts/eventstore/MessagePackAccountEventSerializer.java
@@ -1,8 +1,6 @@
 package lt.rieske.accounts.eventstore;
 
 import lt.rieske.accounts.domain.AccountEvent;
-import lt.rieske.accounts.eventsourcing.Event;
-import lt.rieske.accounts.eventsourcing.EventVisitor;
 import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
@@ -22,15 +20,13 @@ class MessagePackAccountEventSerializer implements EventSerializer<AccountEvent>
     private static final int ACCOUNT_CLOSED = 4;
 
     @Override
-    public byte[] serialize(Event event) {
-        var packer = MessagePack.newDefaultBufferPacker();
-        var serializer = new Serializer(packer);
-        if (event instanceof AccountEvent accountEvent) {
-            serializer.visit(accountEvent);
-        } else {
-            throw new IllegalArgumentException("Can not serialize " + event.getClass());
+    public byte[] serialize(AccountEvent event) {
+        try (var packer = MessagePack.newDefaultBufferPacker()) {
+            pack(packer, event);
+            return packer.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
-        return packer.toByteArray();
     }
 
     @Override
@@ -40,6 +36,29 @@ class MessagePackAccountEventSerializer implements EventSerializer<AccountEvent>
             return deserializeEvent(eventType, unpacker);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void pack(MessageBufferPacker packer, AccountEvent event) throws IOException {
+        switch (event) {
+            case AccountEvent.AccountSnapshot snapshot -> {
+                packer.packInt(ACCOUNT_SNAPSHOT);
+                packUUID(packer, snapshot.accountId());
+                packUUID(packer, snapshot.ownerId());
+                packer.packLong(snapshot.balance())
+                        .packBoolean(snapshot.open());
+            }
+            case AccountEvent.AccountOpenedEvent accountOpened -> {
+                packer.packInt(ACCOUNT_OPENED);
+                packUUID(packer, accountOpened.ownerId());
+            }
+            case AccountEvent.AccountClosedEvent accountClosed -> packer.packInt(ACCOUNT_CLOSED);
+            case AccountEvent.MoneyDepositedEvent moneyDeposited -> packer.packInt(MONEY_DEPOSITED)
+                    .packLong(moneyDeposited.amountDeposited())
+                    .packLong(moneyDeposited.balance());
+            case AccountEvent.MoneyWithdrawnEvent moneyWithdrawn -> packer.packInt(MONEY_WITHDRAWN)
+                    .packLong(moneyWithdrawn.amountWithdrawn())
+                    .packLong(moneyWithdrawn.balance());
         }
     }
 
@@ -60,68 +79,5 @@ class MessagePackAccountEventSerializer implements EventSerializer<AccountEvent>
 
     private static UUID unpackUUID(MessageUnpacker unpacker) throws IOException {
         return new UUID(unpacker.unpackLong(), unpacker.unpackLong());
-    }
-
-    private static class Serializer implements EventVisitor<AccountEvent> {
-
-        private final MessageBufferPacker packer;
-
-        private Serializer(MessageBufferPacker packer) {
-            this.packer = packer;
-        }
-
-        @Override
-        public void visit(AccountEvent event) {
-            switch (event) {
-                case AccountEvent.AccountSnapshot snapshot -> {
-                    try {
-                        packer.packInt(ACCOUNT_SNAPSHOT);
-                        packUUID(packer, snapshot.accountId());
-                        packUUID(packer, snapshot.ownerId());
-                        packer.packLong(snapshot.balance())
-                                .packBoolean(snapshot.open())
-                                .close();
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-                case AccountEvent.AccountOpenedEvent accountOpened -> {
-                    try {
-                        packer.packInt(ACCOUNT_OPENED);
-                        packUUID(packer, accountOpened.ownerId());
-                        packer.close();
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-                case AccountEvent.AccountClosedEvent accountClosed -> {
-                    try {
-                        packer.packInt(ACCOUNT_CLOSED).close();
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-                case AccountEvent.MoneyDepositedEvent moneyDeposited -> {
-                    try {
-                        packer.packInt(MONEY_DEPOSITED)
-                                .packLong(moneyDeposited.amountDeposited())
-                                .packLong(moneyDeposited.balance())
-                                .close();
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-                case AccountEvent.MoneyWithdrawnEvent moneyWithdrawn -> {
-                    try {
-                        packer.packInt(MONEY_WITHDRAWN)
-                                .packLong(moneyWithdrawn.amountWithdrawn())
-                                .packLong(moneyWithdrawn.balance())
-                                .close();
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-            }
-        }
     }
 }

--- a/eventstore/src/main/java/lt/rieske/accounts/eventstore/EventStoreFactory.java
+++ b/eventstore/src/main/java/lt/rieske/accounts/eventstore/EventStoreFactory.java
@@ -49,17 +49,21 @@ public final class EventStoreFactory {
 
     private static void waitForDatabaseToBeAvailable(DataSource dataSource) {
         var retryPeriod = Duration.ofSeconds(1);
+        SQLException lastFailure = null;
         for (int i = 0; i < 20; i++) {
             try (var conn = dataSource.getConnection()) {
-                break;
+                return;
             } catch (SQLException e) {
+                lastFailure = e;
                 log.info("Could not establish connection to the database: attempt {}, sleeping for {}ms", i, retryPeriod.toMillis());
                 try {
                     Thread.sleep(retryPeriod.toMillis());
                 } catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for database to become available", interruptedException);
                 }
             }
         }
+        throw new IllegalStateException("Could not establish connection to the database after retries", lastFailure);
     }
 }

--- a/eventstore/src/main/java/lt/rieske/accounts/eventstore/PostgresEventStore.java
+++ b/eventstore/src/main/java/lt/rieske/accounts/eventstore/PostgresEventStore.java
@@ -48,9 +48,14 @@ class PostgresEventStore implements BlobEventStore {
 
         try (var connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);
-            insertEvents(connection, serializedEvents);
-            updateSnapshots(connection, serializedSnapshots);
-            connection.commit();
+            try {
+                insertEvents(connection, serializedEvents);
+                updateSnapshots(connection, serializedSnapshots);
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            }
         } catch (SQLIntegrityConstraintViolationException e) {
             throw new ConcurrentModificationException(e);
         } catch (PSQLException e) {


### PR DESCRIPTION
Compose EventReplayer instead of read/write stream inheritance, type
MessagePack serialize(E), fail fast on DB wait, and rollback failed appends.